### PR TITLE
Added network name vars to uh-iaas

### DIFF
--- a/terraform/deployments/uh-iaas/main.tf
+++ b/terraform/deployments/uh-iaas/main.tf
@@ -32,7 +32,7 @@ module "cluster" {
     worker_node_flavor = "${var.worker_node_flavor}"
     node_flavor = "${var.node_flavor}"
     coreos_image = "${var.coreos_image}"
-    public_v4_network = "${var.public_v4_network}"
+    network = "${var.network}"
     availability_zone = "${var.availability_zone}"
     cluster_name = "${module.global.cluster_name}"
     cluster_dns_domain = "${var.cluster_dns_domain}"

--- a/terraform/deployments/uh-iaas/terraform.tfvars
+++ b/terraform/deployments/uh-iaas/terraform.tfvars
@@ -1,5 +1,5 @@
 node_flavor = "m1.medium"
 worker_node_flavor = "m1.medium"
-public_v4_network = "dab01c68-c25d-4051-ad5b-7b7b07f16f05"
+network = "dualStack"
 auth_url = "https://api.uh-iaas.no:5000/v3"
 domain_name = "dataporten"

--- a/terraform/deployments/uh-iaas/variables.tf
+++ b/terraform/deployments/uh-iaas/variables.tf
@@ -8,7 +8,7 @@ variable "region" {}
 variable "worker_node_flavor" {}
 variable "node_flavor" {}
 variable "coreos_image" {}
-variable "public_v4_network" {}
+variable "network" {}
 variable "availability_zone" {}
 
 # Cluster data, needs to be set in local.tfvars

--- a/terraform/providers/openstack/cluster_without_floating_ip/main.tf
+++ b/terraform/providers/openstack/cluster_without_floating_ip/main.tf
@@ -7,7 +7,7 @@ variable "region" {}
 variable "worker_node_flavor" {}
 variable "node_flavor" {}
 variable "coreos_image" {}
-variable "public_v4_network" {}
+variable "network" {}
 variable "availability_zone" {}
 variable "cluster_name" {}
 variable "cluster_dns_domain" {}
@@ -55,6 +55,7 @@ module "masters" {
     cluster_name = "${var.cluster_name}"
     count = "${var.master_count}"
     keypair = "${module.keypair.name}"
+    network = "${var.network}"
     sec_groups = [ "default", "${module.securitygroups.ssh}", "${module.securitygroups.master}" ]
 }
 
@@ -69,4 +70,5 @@ module "workers" {
     count = "${var.worker_count}"
     keypair = "${module.keypair.name}"
     sec_groups = [ "default", "${module.securitygroups.ssh}", "${module.securitygroups.lb}" ]
+    network = "${var.network}"
 }

--- a/terraform/providers/openstack/master_without_floating_ip/main.tf
+++ b/terraform/providers/openstack/master_without_floating_ip/main.tf
@@ -4,7 +4,7 @@ variable "image" {}
 variable "count" {}
 variable "cluster_name" {}
 variable "keypair" {}
-#variable "network" {}
+variable "network" {}
 variable "sec_groups" { type = "list" }
 variable "availability_zone" {}
 
@@ -17,6 +17,10 @@ resource "openstack_compute_instance_v2" "master" {
     flavor_name = "${var.flavor}"
     key_pair = "${var.keypair}"
     availability_zone = "${var.availability_zone}"
+
+    network = {
+      name = "${var.network}"
+    }
 
     security_groups = ["${var.sec_groups}"]
     user_data = "#cloud-config\nhostname: ${var.cluster_name}-master-${count.index}\n"

--- a/terraform/providers/openstack/worker_without_floating_ip/main.tf
+++ b/terraform/providers/openstack/worker_without_floating_ip/main.tf
@@ -4,7 +4,7 @@ variable "image" {}
 variable "count" {}
 variable "cluster_name" {}
 variable "keypair" {}
-#variable "network" {}
+variable "network" {}
 variable "sec_groups" { type = "list" }
 variable "availability_zone" {}
 
@@ -17,6 +17,9 @@ resource "openstack_compute_instance_v2" "worker" {
     image_id = "${var.image}"
     key_pair = "${var.keypair}"
     availability_zone = "${var.availability_zone}"
+    network = {
+      name = "${var.network}"
+    }
 
     security_groups = ["${var.sec_groups}"]
     user_data = "#cloud-config\nhostname: ${var.cluster_name}-worker-${count.index}\n"


### PR DESCRIPTION
UH-IaaS introduced a new network a few weeks ago. Now we need to name the network to use in `terraform.ftvars`